### PR TITLE
番組の非表示機能実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -826,10 +826,23 @@ footer {
 
   a {
     transition: all 0.2s ease;
-    
+
     &:hover {
       color: #fff !important;
       transform: translateY(-2px);
     }
   }
+}
+
+.unpublished-program-badge {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background-color: rgba(220, 53, 69, 0.1);
+  border: 1px solid rgba(220, 53, 69, 0.2);
+  border-radius: 0.5rem;
+  color: #dc3545;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   def user_not_authorized
     flash[:alert] = "このアクションは許可されていません"
-    redirect_to(request.referrer || root_path)
+    redirect_to root_path
   end
 end

--- a/app/controllers/auto_complete_controller.rb
+++ b/app/controllers/auto_complete_controller.rb
@@ -5,7 +5,7 @@ class AutoCompleteController < ApplicationController
 
     @objects = case @model.to_s
     when "Program"
-      Program.search(params[:q])
+      Program.where(publish: true).search(params[:q])
     when "Letterbox"
       @program.letterboxes.search(params[:q])
     when "Letter"

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -92,7 +92,7 @@ class ProgramsController < ApplicationController
     end
 
     def program_params
-      params.require(:program).permit(:title, :body, :image)
+      params.require(:program).permit(:title, :body, :image, :publish)
     end
 
     def process_and_transform_image(image_io)

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -4,7 +4,7 @@ class ProgramsController < ApplicationController
   before_action :email_registered_user, only: %i[ new create edit update destroy ]
 
   def index
-    @q = Program.includes(:user).all.order(created_at: :desc).ransack(params[:q])
+    @q = Program.includes(:user).where(publish: true).order(created_at: :desc).ransack(params[:q])
     @programs = @q.result(distinct: true).page(params[:page]).per(6)
     authorize @programs
   end

--- a/app/controllers/static_page_controller.rb
+++ b/app/controllers/static_page_controller.rb
@@ -1,6 +1,6 @@
 class StaticPageController < ApplicationController
   def top
-    @programs = Program.includes(:user).where(publish: true)order(created_at: :desc).limit(5)
+    @programs = Program.includes(:user).where(publish: true).order(created_at: :desc).limit(5)
     @letterboxes = Letterbox.includes(:program).where(publish: true).order(created_at: :desc).limit(3)
     @rankings = ProgramRanking.all.includes(:program)
   end

--- a/app/controllers/static_page_controller.rb
+++ b/app/controllers/static_page_controller.rb
@@ -1,7 +1,7 @@
 class StaticPageController < ApplicationController
   def top
-    @programs = Program.includes(:user).order(created_at: :desc).limit(5)
-    @letterboxes = Letterbox.includes(:program).order(created_at: :desc).limit(3)
+    @programs = Program.includes(:user).where(publish: true)order(created_at: :desc).limit(5)
+    @letterboxes = Letterbox.includes(:program).where(publish: true).order(created_at: :desc).limit(3)
     @rankings = ProgramRanking.all.includes(:program)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,11 @@ class UsersController < ApplicationController
 
   def show
     authorize @user
-    @programs = @user.joined_programs.order(created_at: :desc).page(params[:page]).per(6)
+    if @user == current_user
+      @programs = @user.joined_programs.order(created_at: :desc).page(params[:page]).per(6)
+    else
+      @programs = @user.joined_programs.where(publish: true).order(created_at: :desc).page(params[:page]).per(6)
+    end
     @letters = @user.letters.includes(:program).page(params[:page]).per(10)
   end
 

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -4,7 +4,7 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    record.publish? || user&.admin? || program_producer?
   end
 
   def create?

--- a/app/views/letterboxes/edit.html.erb
+++ b/app/views/letterboxes/edit.html.erb
@@ -10,8 +10,8 @@
 
     <%= render "form", program: @program, letterbox: @letterbox %>
   </div>
-  <%= link_to 'javascript:history.back()', class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
+  <%= link_to program_letterboxes_path(program:@program), class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
         <i class="bi bi-arrow-left me-2"></i>
-        戻る
+        お便り箱詳細へ戻る
   <% end %>
 </div>

--- a/app/views/letterboxes/index.html.erb
+++ b/app/views/letterboxes/index.html.erb
@@ -81,8 +81,8 @@
     <% end %>
   </div>
 
-  <%= link_to 'javascript:history.back()', class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
+  <%= link_to @program, class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
     <i class="bi bi-arrow-left me-2"></i>
-    戻る
+    番組詳細へ戻る
   <% end %>
 </div>

--- a/app/views/letters/index.html.erb
+++ b/app/views/letters/index.html.erb
@@ -107,8 +107,8 @@
     <% end %>
   </div>
 
-  <%= link_to 'javascript:history.back()', class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
+  <%= link_to @program, class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
     <i class="bi bi-arrow-left me-2"></i>
-    戻る
+    番組詳細へ戻る
   <% end %>
 </div>

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -24,6 +24,11 @@
     </div>
 
     <div class="mb-4">
+      <%= form.label :publish, class: "form-label" %>
+      <%= form.check_box :publish, class: "form-check-input" %>
+    </div>
+
+    <div class="mb-4">
       <%= form.label :image, "画像", class: "form-label" %>
       <%= form.file_field :image,
           class: "form-control",

--- a/app/views/programs/_program.html.erb
+++ b/app/views/programs/_program.html.erb
@@ -10,6 +10,13 @@
           </h4>
         </div>
 
+        <% unless program.publish? %>
+          <div class="unpublished-program-badge mb-4">
+            <i class="bi bi-eye-slash me-2"></i>
+            非公開の番組です
+          </div>
+        <% end %>
+
         <% if action_name == "index" %>
           <p class="text-gradient mb-3"><%= "総お便り数：#{program.letters.count} 件"%></p>
         <% end %>

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -24,6 +24,19 @@
           <% end %>
         </div>
       </div>
+            <div class="glass-morphism p-4 mb-4">
+        <div class="d-flex justify-content-between align-items-center">
+          <h2 class="text-gradient h4 mb-0">
+            <i class="bi bi-person-plus me-2"></i>
+            この番組の公開設定
+          </h2>
+          <div class="d-flex justify-content-end align-items-center mt-3">
+            <div class="d-flex align-items-center gap-3 text-white-50">
+              <%= render "shared/publish_buttons", object: @program, program: @program %>
+            </div>
+          </div>
+        </div>
+      </div>
     <% end %>
     <div class="py-3">
       <div class="glass-morphism p-4 mb-3">

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -27,11 +27,11 @@
             <div class="glass-morphism p-4 mb-4">
         <div class="d-flex justify-content-between align-items-center">
           <h2 class="text-gradient h4 mb-0">
-            <i class="bi bi-person-plus me-2"></i>
+            <i class="bi bi-eye-fill"></i>
             この番組の公開設定
           </h2>
           <div class="d-flex justify-content-end align-items-center mt-3">
-            <div class="d-flex align-items-center gap-3 text-white-50">
+            <div class="d-flex align-items-center text-white-50">
               <%= render "shared/publish_buttons", object: @program, program: @program %>
             </div>
           </div>
@@ -79,9 +79,9 @@
     <% end %>
 
     <div class="mt-4 d-flex gap-3">
-      <%= link_to 'javascript:history.back()', class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
+      <%= link_to @program, class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
           <i class="bi bi-arrow-left me-2"></i>
-          戻る
+          番組詳細へ戻る
       <% end %>
     </div>
   </div>

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -24,7 +24,7 @@
           <% end %>
         </div>
       </div>
-            <div class="glass-morphism p-4 mb-4">
+      <div class="glass-morphism p-4 mb-4">
         <div class="d-flex justify-content-between align-items-center">
           <h2 class="text-gradient h4 mb-0">
             <i class="bi bi-eye-fill"></i>

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -141,8 +141,8 @@
     <%= render "letters/form", letter: @letter, program: @program %>
   </div>
 
-  <%= link_to 'javascript:history.back()', class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
+  <%= link_to programs_path, class: "btn btn-outline-light rounded-pill px-4 hover-lift" do %>
     <i class="bi bi-arrow-left me-2"></i>
-    戻る
+    番組一覧へ戻る
   <% end %>
 </div>

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -9,6 +9,12 @@
           <i class="bi bi-broadcast-pin me-3"></i>
           <%= @program.title %>
         </h1>
+        <% unless @program.publish? %>
+          <div class="unpublished-program-badge mb-4">
+            <i class="bi bi-eye-slash me-2"></i>
+            非公開の番組です
+          </div>
+        <% end %>
 
         <h4 class="text-gradient mb-4"><%= "総お便り数：#{@program.letters.count} 件"%></h4>
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,15 +16,18 @@ ja:
         title: タイトル
         body: 番組の説明
         image: 画像
+        publish: 公開設定
       letterbox:
         title: タイトル
         body: お便り箱の説明
+        publish: 公開設定
       letter:
         radio_name: ラジオネーム
         letterbox_id: お便り箱
         title: タイトル
         body: 本文
         letterbox: お便り箱
+        publish: 公開設定
       program_ranking:
         program_id: "番組ID"
         letters_count: "お便り数"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,6 @@ Rails.application.routes.draw do
   resources :programs do
     resources :letterboxes, only: %i[ index new create edit update destroy ]
     resources :letters, only: %i[ show index new create destroy ], shallow: true do
-      post "/publish", to: "letter_status#publish"
-      post "/non_publish", to: "letter_status#non_publish"
       post "/read", to: "letter_status#read"
       post "/unread", to: "letter_status#unread"
     end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -12,9 +12,12 @@
 
 if Rails.env.development? || Rails.env.test?
   31.times do
-    User.create!(name: Faker::Games::Overwatch.unique.hero,
-                password: "password",
-                password_confirmation: "password")
+    User.create!(
+      name: Faker::Games::Overwatch.unique.hero,
+      password: "password",
+      password_confirmation: "password",
+      confirmed_at: Time.current
+    )
   end
 
   user_ids = User.ids
@@ -42,10 +45,12 @@ if Rails.env.development? || Rails.env.test?
   # letters
   100.times do |index|
     letterbox = Letterbox.find(letterbox_ids.sample)
-    letterbox.letters.create!(title: "letterタイトル#{index}",
-                              body: "letter本文#{Faker::Games::Overwatch.quote}",
-                              user_id: user_ids.sample,
-                              radio_name: Faker::Name.unique.first_name,
-                              program_id: letterbox.program.id)
+    letterbox.letters.create!(
+      title: "letterタイトル#{index}",
+      body: "letter本文#{Faker::Games::Overwatch.quote}",
+      user_id: user_ids.sample,
+      radio_name: "ラジオネーム#{index}", # Fakerの代わりに連番を使用
+      program_id: letterbox.program.id
+    )
   end
 end

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -12,9 +12,12 @@
 
 if Rails.env.development? || Rails.env.test?
   31.times do
-    User.create!(name: Faker::Games::Overwatch.unique.hero,
-                password: "password",
-                password_confirmation: "password")
+    User.create!(
+      name: Faker::Games::Overwatch.unique.hero,
+      password: "password",
+      password_confirmation: "password",
+      confirmed_at: Time.current
+    )
   end
 
   user_ids = User.ids
@@ -42,10 +45,12 @@ if Rails.env.development? || Rails.env.test?
   # letters
   100.times do |index|
     letterbox = Letterbox.find(letterbox_ids.sample)
-    letterbox.letters.create!(title: "letterタイトル#{index}",
-                              body: "letter本文#{Faker::Games::Overwatch.quote}",
-                              user_id: user_ids.sample,
-                              radio_name: Faker::Name.unique.first_name,
-                              program_id: letterbox.program.id)
+    letterbox.letters.create!(
+      title: "letterタイトル#{index}",
+      body: "letter本文#{Faker::Games::Overwatch.quote}",
+      user_id: user_ids.sample,
+      radio_name: "ラジオネーム#{index}", # Fakerの代わりに連番を使用
+      program_id: letterbox.program.id
+    )
   end
 end

--- a/lib/tasks/ranking.rake
+++ b/lib/tasks/ranking.rake
@@ -3,12 +3,14 @@ namespace :ranking do
   task update_ranking: :environment do
     ProgramRanking.delete_all
 
-    rankings = Letter.where(created_at: 2.weeks.ago..)
-                      .where.not(program_id: nil)
-                      .group(:program_id)
-                      .select("program_id, COUNT(id) as letters_count")
-                      .order("letters_count DESC")
-                      .limit(10)
+    rankings = Letter.joins(:program)
+                     .where(created_at: 2.weeks.ago..)
+                     .where(programs: { publish: true })
+                     .where.not(program_id: nil)
+                     .group(:program_id)
+                     .select("program_id, COUNT(letters.id) as letters_count")
+                     .order("letters_count DESC")
+                     .limit(10)
 
     ActiveRecord::Base.transaction do
       rankings.each do |result|


### PR DESCRIPTION
# 概要
コントローラーで受け渡す値やviewでの表示を追加し番組の非表示機能を実装

## 内容
- TOPの勢いランキングや最近追加された番組やお便り箱が`publish: true`に設定されている物のみになるようにコントローラーの記述を変更
- 非表示の番組に対して非表示であることをわかりやすく表示
- 勢いランキングも`publish: true`である物のみからランキングを作成するように設定
- 非表示の番組は管理者、もしくは番組の管理をしているユーザーのみ確認できるようにユーザー詳細、番組詳細画面への値を渡すためのコントローラーの記述変更
- punditによる認可チェックが失敗した際のリダイレクト先がバグを引き起こしていたので`root_path`のみになるように設定
- 番組詳細ページのポリシー追加
- 番組作成時の公開設定ボタン追加