### PR TITLE
番組のサムネイル画像投稿機能の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
 # デバック用ロガー（やまさかなさん作）
-gem 'swimming_fish', '~> 0.2.2'
+gem "swimming_fish", "~> 0.2.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "pundit"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
+# デバック用ロガー（やまさかなさん作）
+gem 'swimming_fish', '~> 0.2.2'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,6 +446,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
+    swimming_fish (0.2.2)
     thor (1.3.2)
     thruster (0.1.8-x86_64-linux)
     timeout (0.4.2)
@@ -517,6 +518,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
+  swimming_fish (~> 0.2.2)
   thruster
   turbo-rails
   tzinfo-data

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -147,7 +147,7 @@ class ProgramsController < ApplicationController
           filename: "#{File.basename(image_io.original_filename, '.*')}.webp",
         )
 
-        return result
+        result
       rescue => e
         logger.swim "Image processing error: #{e.message}"
         raise e

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -56,17 +56,26 @@ class ProgramsController < ApplicationController
   def update
     # まず属性の更新のみを行う
     @program.assign_attributes(program_params)
+    logger.swim(program_params)
+    logger.swim(@program.image.class)
+    logger.swim(@program.image.inspect)
     authorize @program
 
     if @program.valid?
       # 画像処理が必要な場合のみ実行
       if params[:program][:image].present?
+        logger.swim("params[:program][:image].class: #{params[:program][:image].class}")
+        logger.swim("params[:program][:image].inspect: #{params[:program][:image].inspect}")
+        logger.swim "利用可能なメソッド: #{params[:program][:image].methods.sort}"
         process_and_transform_image(params[:program][:image])
+        @program.image = params[:program][:image]
+        logger.swim("params content_type : #{params[:program][:image].content_type}, @program content_type : #{@program.image.content_type}")
       end
 
       # バリデーションが通った場合のみ保存
       if @program.save
         flash[:notice] = "番組を編集しました"
+        logger.swim(@program.image.content_type)
         redirect_to @program
       else
         flash.now[:danger] = "番組を編集できませんでした、番組編集フォームを確認してください"

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -36,7 +36,15 @@ class ProgramsController < ApplicationController
 
     if @program.valid?
       if params[:program][:image].present?
-        process_and_transform_image(params[:program][:image])
+        processed_image = nil
+        begin
+          processed_image = process_and_transform_image(params[:program][:image])
+          @program.image = processed_image
+
+        rescue => e
+          flash.now[:danger] = "画像の処理中にエラーが発生しました: #{e.message}"
+          return render :edit, status: :unprocessable_entity
+        end
       end
 
       if @program.save
@@ -55,67 +63,26 @@ class ProgramsController < ApplicationController
 
   def update
     # まず属性の更新のみを行う
-
-    # ロガー
-    # logger.swim("assin_attributes前　ActiveStorage::Attachment.count : #{ActiveStorage::Attachment.count}")
-    # ロガー
-
     @program.assign_attributes(program_params)
-
-    # ロガー
-    # logger.swim("assin_attributes後　ActiveStorage::Attachment.count : #{ActiveStorage::Attachment.count}")
-    # logger.swim(program_params)
-    # logger.swim(@program.image.class)
-    # logger.swim(@program.image.inspect)
-    # ロガー
 
     authorize @program
 
     if @program.valid?
-
-    # ロガー
-    # logger.swim("@program.valid?後　ActiveStorage::Attachment.count : #{ActiveStorage::Attachment.count}")
-    # ロガー
-
       # 画像処理が必要な場合のみ実行
 
       if params[:program][:image].present?
         processed_image = nil
         begin
-          # ロガー
-          # logger.swim("params[:program][:image].class: #{params[:program][:image].class}")
-          # logger.swim("params[:program][:image].inspect: #{params[:program][:image].inspect}")
-          # logger.swim "利用可能なメソッド: #{params[:program][:image].methods.sort}"
-          # ロガー
-
           processed_image = process_and_transform_image(params[:program][:image])
           @program.image = processed_image
-
-          # ロガー
-          # logger.swim(@program.image.class)
-          # logger.swim(@program.image.inspect)
-          # logger.swim("params content_type : #{params[:program][:image].content_type}, @program content_type : #{@program.image.content_type}")
-          # ロガー
 
         rescue => e
           flash.now[:danger] = "画像の処理中にエラーが発生しました: #{e.message}"
           return render :edit, status: :unprocessable_entity
-        # ensure
-        #   # 処理が終わったら一時ファイルをクローズ・削除
-        #   if processed_image&.tempfile && !processed_image.tempfile.closed?
-        #     processed_image.tempfile.close
-        #     processed_image.tempfile.unlink
-        #   end
         end
       end
 
       if @program.save
-
-        # ロガー
-        # logger.swim("@program.save後　ActiveStorage::Attachment.count : #{ActiveStorage::Attachment.count}")
-        # logger.swim(@program.image.content_type)
-        # ロガー
-
         flash[:notice] = "番組を編集しました"
         redirect_to @program
       else
@@ -173,31 +140,12 @@ class ProgramsController < ApplicationController
         new_tempfile.write(output_buffer)
         new_tempfile.rewind
 
-        # 元のUploadedFileオブジェクトの属性を更新
-        # image_io.tempfile = new_tempfile
-        # image_io.original_filename = "#{File.basename(image_io.original_filename, '.*')}.webp"
-        # image_io.content_type = "image/webp"
-
-        # ロガー
-        # logger.swim("tempfile: #{new_tempfile.path}")
-        # logger.swim("content_type: image/webp")
-        # logger.swim("headers: #{image_io.headers}")
-        # ロガー
-
         # 新しいUploadedFileオブジェクトを作成して返す
         result = ActionDispatch::Http::UploadedFile.new(
           tempfile: new_tempfile,
           type: "image/webp",
           filename: "#{File.basename(image_io.original_filename, '.*')}.webp",
         )
-
-        # 作成されたオブジェクトを確認
-        # ロガー
-        # logger.swim("Created UploadedFile: #{result.inspect}")
-        # logger.swim("Content type: #{result.content_type}")
-        # logger.swim("Original filename: #{result.original_filename}")
-        # logger.swim result.inspect
-        # ロガー
 
         return result
       rescue => e

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,9 @@
     <div class="d-flex flex-column flex-md-row justify-content-center align-items-center gap-3">
       <%= link_to "利用規約", terms_path, class: "text-white-50 text-decoration-none hover-lift" %>
       <%= link_to "プライバシーポリシー", privacy_policy_path, class: "text-white-50 text-decoration-none hover-lift" %>
-      <p class="text-white-50 text-decoration-none">お問い合わせ：<%= mail_to ENV['SUPPORT_EMAIL'], nil, class: 'text-decoration-none' %></p>
+      <% if false %>
+        <p class="text-white-50 text-decoration-none">お問い合わせ：<%= mail_to ENV['SUPPORT_EMAIL'], nil, class: 'text-decoration-none' %></p>
+      <% end %>
     </div>
     <p class="text-center text-white-50 mt-3 mb-0">&copy; 2024 Music Hour</p>
   </div>


### PR DESCRIPTION
# 概要
- 画像を投稿後メタデータが変更されていなかった問題の修正

## 内容
- 今回の問題は一時ファイルの画像を直接加工し、その後メタデータも代入していたが、`assign_attributes`を行った後に再度更新していなかったため、画像は加工後の一時ファイルが実際に保存されてしまい、メタデータ等は保存されていなかったこと
- バリデーションチェック後に画像を加工、その後、その加工した画像で一時ファイルを新規で作成しそれを`@program.image`に適用し、他のカラムと同時に保存するように変更
