### PR TITLE
メモリの仕様率を考えたものに調整＆少しの修正

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -115,7 +115,7 @@ class ProgramsController < ApplicationController
         image_io.tempfile.rewind
 
         processed_image = input_image.thumbnail_image(
-        # アスペクト比を維持しながらリサイズ
+          # アスペクト比を維持しながらリサイズ
           854,
           height: 480,
           size: :down,


### PR DESCRIPTION
# 概要
- 編集中の画像が複数になってしまっており画像加工処理のメモリ使用量が大きくなる懸念があった

## 内容
- 画像加工処理中のメモリ使用量を減らすために変数に保存する部分を減らした
- createアクションの画像加工処理失敗時の遷移先を修正