### PR TITLE
画像処理のロジックのリファクタリングと切り分け

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -36,7 +36,7 @@ class ProgramsController < ApplicationController
 
     if @program.valid?
       begin
-        @program.image = @program.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
+        @program.image = ImageProcessable.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
         if @program.save
           flash[:notice] = "番組を作成しました"
           redirect_to @program
@@ -57,7 +57,7 @@ class ProgramsController < ApplicationController
 
     if @program.valid?
       begin
-        @program.image = @program.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
+        @program.image = ImageProcessable.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
         if @program.save
           flash[:notice] = "番組を編集しました"
           redirect_to @program

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -35,21 +35,14 @@ class ProgramsController < ApplicationController
     authorize @program
 
     if @program.valid?
-      if params[:program][:image].present?
-        begin
-          @program.image = process_and_transform_image(params[:program][:image])
-        rescue => e
-          flash.now[:danger] = "画像の処理中にエラーが発生しました: #{e.message}"
-          return render :new, status: :unprocessable_entity
+      begin
+        @program.image = @program.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
+        if @program.save
+          flash[:notice] = "番組を作成しました"
+          redirect_to @program
         end
-      end
-
-      if @program.save
-        current_user.user_participations.create(program: @program)
-        flash[:notice] = "番組を作成しました"
-        redirect_to @program
-      else
-        flash.now[:danger] = "番組を作成できませんでした、番組作成フォームを確認してください"
+      rescue ImageProcessable::ImageProcessingError => e
+        flash.now[:danger] = e.message
         render :new, status: :unprocessable_entity
       end
     else
@@ -59,28 +52,18 @@ class ProgramsController < ApplicationController
   end
 
   def update
-    # まず属性の更新のみを行う
     @program.assign_attributes(program_params)
-
     authorize @program
 
     if @program.valid?
-      # 画像処理が必要な場合のみ実行
-
-      if params[:program][:image].present?
-        begin
-          @program.image = process_and_transform_image(params[:program][:image])
-        rescue => e
-          flash.now[:danger] = "画像の処理中にエラーが発生しました: #{e.message}"
-          return render :edit, status: :unprocessable_entity
+      begin
+        @program.image = @program.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
+        if @program.save
+          flash[:notice] = "番組を編集しました"
+          redirect_to @program
         end
-      end
-
-      if @program.save
-        flash[:notice] = "番組を編集しました"
-        redirect_to @program
-      else
-        flash.now[:danger] = "番組を編集できませんでした、番組編集フォームを確認してください"
+      rescue ImageProcessable::ImageProcessingError => e
+        flash.now[:danger] = e.message
         render :edit, status: :unprocessable_entity
       end
     else
@@ -104,46 +87,5 @@ class ProgramsController < ApplicationController
 
     def program_params
       params.require(:program).permit(:title, :body, :image, :publish, :url)
-    end
-
-    def process_and_transform_image(image_io)
-      require "vips"
-
-      begin
-        # 送信された画像を直接処理
-        input_image = Vips::Image.new_from_buffer(image_io.tempfile.read, "")
-        image_io.tempfile.rewind
-
-        processed_image = input_image.thumbnail_image(
-          # アスペクト比を維持しながらリサイズ
-          854,
-          height: 480,
-          size: :down,
-          crop: :none,
-        ).webpsave_buffer(
-          # WebPフォーマットに変換
-          Q: 80,
-          effort: 4,
-          reduction_effort: 2
-        )
-
-        # 新しい一時ファイルを作成して処理済み画像を書き込む
-        new_tempfile = Tempfile.new([ "processed", ".webp" ])
-        new_tempfile.binmode
-        new_tempfile.write(processed_image)
-        new_tempfile.rewind
-
-        # 新しいUploadedFileオブジェクトを作成して返す
-        result = ActionDispatch::Http::UploadedFile.new(
-          tempfile: new_tempfile,
-          type: "image/webp",
-          filename: "#{File.basename(image_io.original_filename, '.*')}.webp",
-        )
-
-        result
-      rescue => e
-        logger.swim "Image processing error: #{e.message}"
-        raise e
-      end
     end
 end

--- a/app/models/concerns/image_processable.rb
+++ b/app/models/concerns/image_processable.rb
@@ -1,7 +1,7 @@
 module ImageProcessable
-  extend ActiveSupport::Concern
-
   class ImageProcessingError < StandardError; end
+
+  module_function
 
   def process_and_transform_image(image_io, width)
     return unless image_io.present?
@@ -14,7 +14,6 @@ module ImageProcessable
         .saver(strip: true, quality: 85)
         .call
 
-      # ActionDispatch::Http::UploadedFileを返す
       ActionDispatch::Http::UploadedFile.new(
         tempfile: processed_image,
         filename: "#{File.basename(image_io.original_filename, '.*')}.webp",

--- a/app/models/concerns/image_processable.rb
+++ b/app/models/concerns/image_processable.rb
@@ -1,0 +1,28 @@
+module ImageProcessable
+  extend ActiveSupport::Concern
+
+  class ImageProcessingError < StandardError; end
+
+  def process_and_transform_image(image_io, width)
+    return unless image_io.present?
+
+    begin
+      processed_image = ImageProcessing::Vips
+        .source(image_io)
+        .resize_to_fit(width, nil)
+        .convert("webp")
+        .saver(strip: true, quality: 85)
+        .call
+
+      # ActionDispatch::Http::UploadedFileを返す
+      ActionDispatch::Http::UploadedFile.new(
+        tempfile: processed_image,
+        filename: "#{File.basename(image_io.original_filename, '.*')}.webp",
+        type: "image/webp"
+      )
+    rescue => e
+      Rails.logger.error "Image processing error: #{e.message}"
+      raise ImageProcessingError, "画像の処理中にエラーが発生しました: #{e.message}"
+    end
+  end
+end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,4 +1,5 @@
 class Program < ApplicationRecord
+  include ImageProcessable
   attr_accessor :invitation_token
 
   validates :title, presence: true,

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -10,7 +10,7 @@
 
 # users
 
-if Rails.env.development? || Rails.env.test?
+if Rails.env.development?
   5001.times do |i|
     User.create!(
       name: "#{Faker::Games::Overwatch.hero}_id_#{i}",

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -11,24 +11,27 @@
 # users
 
 if Rails.env.development? || Rails.env.test?
-  31.times do
+  5001.times do |i|
     User.create!(
-      name: Faker::Games::Overwatch.unique.hero,
+      name: "#{Faker::Games::Overwatch.hero}_id_#{i}",
       password: "password",
       password_confirmation: "password",
-      confirmed_at: Time.current
+      confirmed_at: Time.current,
+      email: "#{Faker::Internet.unique.email}_id_#{i}"
     )
   end
 
   user_ids = User.ids
   user = User.find(1)
-  user.update(name: "massanE", admin: true)
+  user.update(name: "massanE", admin: true, email: "ex@ex.com")
 
   # programs
   50.times do |index|
     user = User.find(user_ids.sample)
     user.programs.create!(title: "番組タイトル#{index}",
-                          body: "番組本文#{Faker::Games::Overwatch.quote}")
+                          body: "番組本文#{Faker::Games::Overwatch.quote}",
+                          publish: true
+                          )
   end
 
   program_ids = Program.ids
@@ -43,14 +46,15 @@ if Rails.env.development? || Rails.env.test?
   letterbox_ids = Letterbox.ids
 
   # letters
-  100.times do |index|
+  100000.times do |index|
     letterbox = Letterbox.find(letterbox_ids.sample)
     letterbox.letters.create!(
       title: "letterタイトル#{index}",
       body: "letter本文#{Faker::Games::Overwatch.quote}",
       user_id: user_ids.sample,
       radio_name: "ラジオネーム#{index}", # Fakerの代わりに連番を使用
-      program_id: letterbox.program.id
+      program_id: letterbox.program.id,
+      star: rand(0..5) # ランダムな星の数を設定
     )
   end
 end


### PR DESCRIPTION
# 概要
以前から考えていた画像処理部分のリファクタリングとconcernsへの切り分けを行った

## 内容
- libvipsを直接的に使った方法ではなくimage_processingを通して処理する方法に変更
- 処理方法を変えほかのモデルでも使用できるように一般化したものを、モデルのconcernsにモジュールとして置いた

