### PR TITLE
細かいバグ修正

### DIFF
--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -108,8 +108,8 @@ class Program < ApplicationRecord
       .where(stared_at: date_range)
       .group(:user)
       .limit(limit)
-      .order(Arel.sql("COUNT(star) DESC"))
-      .count(:star)
+      .order(Arel.sql("SUM(star) DESC"))
+      .sum(:star)
   end
 
   # 現在のランキング期間の表示用文字列

--- a/app/views/letter_status/update_star.turbo_stream.erb
+++ b/app/views/letter_status/update_star.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace dom_id(@letter, :rating) do %>
   <%= render 'letters/rating', letter: @letter %>
-<% end %
+<% end %>


### PR DESCRIPTION
# 概要
- クエリの修正
- Star付与ボタンの表示バグ修正

## 内容
- Starの数を集計してランキングをつけるのではなく、Starがついてるお便りを数えてランキングつけてたのでSQLを修正して、Starをユーザーごとに集計してランキングをつけるようにした。
- letterパーシャルのStar付与のボタンを押して確定を押したときに`Content missing`と表示されていたので、tourboファイルの記述ミスを修正