### PR TITLE
新規作成した番組がユーザーと紐づかないバグ修正

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -40,6 +40,7 @@ class ProgramsController < ApplicationController
       begin
         @program.image = ImageProcessable.process_and_transform_image(params[:program][:image], 854) if params[:program][:image].present?
         if @program.save
+          current_user.user_participations.create(program: @program)
           flash[:notice] = "番組を作成しました"
           redirect_to @program
         end

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -174,7 +174,7 @@
                     <div class="title w-100">
                       <div class="d-flex justify-content-between align-items-center">
                         <h4 class="card-title h5 mb-0 scroll">
-                            <%= i + 1 %>. <%= @program.letters.where(user: user).last&.radio_name || "名無しさん" %>
+                          <%= i + 1 %>. <span class="text-gradient fw-bold me-2"><%= @program.letters.where(user: user).last&.radio_name || "loving rabbit" %></span>
                         </h4>
                         <span class="badge bg-dark text-warning fs-5">
                           <i class="bi bi-star-fill me-1"></i> <%= star %>


### PR DESCRIPTION
# 概要
新規作成した番組が作成したユーザーと紐づかないバグの修正

## 内容
関連プルリク：#256
関連プルリクの際に新規作成時にユーザーの主催している番組を管理するテーブルに関連を保存する部分の処理を消してしまっていたことが原因だったのでその部分を修正